### PR TITLE
Jaehuyng/상세페이지-앱바 변경 , + 리드미 상단변경(최신 버전의 HTML에서는 align 속성이 더 이상 사용되지X)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align=center>
+<div style="text-align: center;">
 	<img src="https://capsule-render.vercel.app/api?type=waving&color=auto&height=200&section=header&text=brabu-team!&fontSize=90"  alt=""/>	
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align=center>
-	<img src="https://capsule-render.vercel.app/api?type=waving&color=auto&height=200&section=header&text=brabu-team!&fontSize=90" />	
+	<img src="https://capsule-render.vercel.app/api?type=waving&color=auto&height=200&section=header&text=brabu-team!&fontSize=90"  alt=""/>	
 </div>
 
 # 식집사들을 위한 식물 구매 키오스크

--- a/lib/list/information_detail.dart
+++ b/lib/list/information_detail.dart
@@ -1,9 +1,5 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
-import 'package:greentouch/layout/appbar.dart';
 
-import '../layout/app_drawer.dart';
 import '../mypage/tab_cart.dart';
 
 void main() {
@@ -14,6 +10,7 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
+
   // 어플리케이션의 루트 위젯입니다.
   @override
   Widget build(BuildContext context) {
@@ -40,8 +37,17 @@ class _InformationDetailState extends State<InformationDetail> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: BaseAppBar(),
-      drawer: AppDrawer(),
+      appBar: AppBar(
+        title: Center(
+          child: Image.asset(
+            'assets/images/logo.png',
+            fit: BoxFit.contain,
+            scale: 4.5,
+          ),
+        ),
+      ),
+
+      //drawer: AppDrawer(),
       body: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/list/productlist.dart
+++ b/lib/list/productlist.dart
@@ -165,7 +165,7 @@ class _ProductListState extends State<ProductList> {
                   subtitle: 'subtitle',
                   price: pprice,
                   onTap: () {
-                    Navigator.pushReplacement(
+                    Navigator.push(
                         context,
                         MaterialPageRoute(
                           builder: (context) => InformationDetail(),


### PR DESCRIPTION
화살표로 기존 base앱바 사용안하고, 바꿨습니다. 

+ P.S ( readme에서 <div align=center>입니다. 이는 HTML 요소인데, 최신 버전의 HTML에서는 align 속성이 더 이상 사용되지 않습니다. 대신 CSS를 사용하여 요소를 가운데 정렬할 수 있습니다.

따라서 이 부분을 수정하여 CSS를 사용하여 가운데 정렬을 적용해야 합니다. 아래는 해당 부분을 CSS를 사용하여 수정합니다.

--<기존>--
<div align=center>

--<변경>-- 
<div style="text-align: center;">
    <img src="https://capsule-render.vercel.app/api?type=waving&color=auto&height=200&section=header&text=brabu-team!&fontSize=90"  alt=""/>	
</div>
- 리드미 제일 상단도 문제없이 커밋/푸쉬되어서  같이 변경합니다. )